### PR TITLE
feat: Windows compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ chrono = { version = "0.4", features = ["serde"] }
 owo-colors = "4.1"
 anyhow = "1.0"
 fs2 = "0.4"
-libc = "0.2"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "logg
 clap = { version = "4.5", features = ["derive"] }
 semver = "1.0"
 inquire = "0.9"
+dunce = "1.0"
+path-slash = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ inquire = "0.9"
 dunce = "1.0"
 path-slash = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1", features = ["process"] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ semver = "1.0"
 inquire = "0.9"
 dunce = "1.0"
 path-slash = "0.2"
+which = "8"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "1", features = ["process"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ High-performance statusline for Claude Code that displays real-time usage metric
 - **Interactive mode** - Works as standalone tool or piped statusline
 - **OAuth authentication** - Uses Claude Code's native OAuth tokens from ~/.claude/.credentials.json
 - **Accurate cost tracking** - Fetches daily pricing from LiteLLM, supports tiered pricing
-- **Smart caching** - XDG_RUNTIME_DIR-based caching with 24-hour pricing cache
+- **Smart caching** - XDG_RUNTIME_DIR-based caching (falls back to `$TEMP` on Windows) with 24-hour pricing cache
 - **5-hour block tracking** - Matches Claude's billing cycles exactly
 - **Deduplication** - Prevents double-counting duplicate JSONL entries
 - **Burn rate monitoring** - Real-time cost per hour with visual indicators
@@ -32,13 +32,27 @@ This project is a Rust reimplementation of the statusline feature from [ccusage]
 
 ## Installation
 
-### Quick Install
+### Linux / macOS
 
 ```bash
 cargo build --release
 sudo cp target/release/ccusage-statusline-rs /usr/local/bin/
 ccusage-statusline-rs install
 ```
+
+### Windows
+
+```powershell
+cargo build --release
+Copy-Item target\release\ccusage-statusline-rs.exe "$env:USERPROFILE\.local\bin\"
+ccusage-statusline-rs install
+```
+
+> **Note:** on Windows, Claude Code invokes the statusLine command through Git Bash. The
+> `install` command handles this automatically by writing the path with forward slashes.
+> If you configure the path manually, use forward slashes (`C:/Users/...`) rather than
+> backslashes, otherwise Git Bash will silently misinterpret the path and the status line
+> will not appear.
 
 The `install` command will automatically configure `~/.claude/settings.json` for you.
 
@@ -48,7 +62,7 @@ The `install` command will automatically configure `~/.claude/settings.json` for
 cargo build --release
 ```
 
-The binary will be at `target/release/ccusage-statusline-rs`.
+The binary will be at `target/release/ccusage-statusline-rs` (`.exe` on Windows).
 
 ## Usage
 
@@ -124,7 +138,9 @@ If you prefer to manually configure, add to your `~/.claude/settings.json`:
 }
 ```
 
-Replace `/path/to/` with the actual path to the binary.
+Replace `/path/to/` with the actual path to the binary. On Windows, use forward slashes
+(`C:/Users/yourname/.local/bin/ccusage-statusline-rs.exe`) — backslashes will not work
+because Claude Code invokes the command through Git Bash.
 
 ## Performance
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,11 +6,22 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-/// Get cache directory from XDG_RUNTIME_DIR, scoped per config dir
+/// Get cache directory from XDG_RUNTIME_DIR, scoped per config dir.
+/// Fallback on Unix is per-user `/run/user/<uid>` (mode 0700, tmpfs); on
+/// non-Unix targets it is `std::env::temp_dir()`.
 pub fn get_cache_dir() -> Result<PathBuf> {
     let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(std::env::temp_dir);
+        .unwrap_or_else(|| {
+            #[cfg(unix)]
+            {
+                PathBuf::from(format!("/run/user/{}", rustix::process::getuid().as_raw()))
+            }
+            #[cfg(not(unix))]
+            {
+                std::env::temp_dir()
+            }
+        });
     let config_dir = crate::paths::claude_config_dir()?;
     let config_name = config_dir
         .file_name()

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -8,15 +8,16 @@ use std::path::{Path, PathBuf};
 
 /// Get cache directory from XDG_RUNTIME_DIR, scoped per config dir
 pub fn get_cache_dir() -> Result<PathBuf> {
-    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
-        .unwrap_or_else(|_| format!("/run/user/{}", unsafe { libc::getuid() }));
+    let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
     let config_dir = crate::paths::claude_config_dir()?;
     let config_name = config_dir
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or(".claude")
         .trim_start_matches('.');
-    Ok(PathBuf::from(runtime_dir)
+    Ok(runtime_dir
         .join("ccusage-statusline-rs")
         .join(config_name))
 }

--- a/src/claude_binary.rs
+++ b/src/claude_binary.rs
@@ -16,29 +16,7 @@ struct VersionCache {
 
 /// Get Claude binary path from PATH
 fn get_claude_binary_path() -> Option<PathBuf> {
-    let locator = if cfg!(windows) { "where" } else { "which" };
-    let output = Command::new(locator)
-        .arg("claude")
-        .output()
-        .ok()?;
-
-    if !output
-        .status
-        .success()
-    {
-        return None;
-    }
-
-    let stdout = String::from_utf8(output.stdout).ok()?;
-    // `where` can return multiple lines; take the first.
-    let first = stdout
-        .lines()
-        .next()?
-        .trim();
-    if first.is_empty() {
-        return None;
-    }
-    Some(PathBuf::from(first))
+    which::which("claude").ok()
 }
 
 /// Get binary modification time as unix timestamp

--- a/src/claude_binary.rs
+++ b/src/claude_binary.rs
@@ -16,7 +16,8 @@ struct VersionCache {
 
 /// Get Claude binary path from PATH
 fn get_claude_binary_path() -> Option<PathBuf> {
-    let output = Command::new("which")
+    let locator = if cfg!(windows) { "where" } else { "which" };
+    let output = Command::new(locator)
         .arg("claude")
         .output()
         .ok()?;
@@ -28,8 +29,16 @@ fn get_claude_binary_path() -> Option<PathBuf> {
         return None;
     }
 
-    let path_str = String::from_utf8(output.stdout).ok()?;
-    Some(PathBuf::from(path_str.trim()))
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    // `where` can return multiple lines; take the first.
+    let first = stdout
+        .lines()
+        .next()?
+        .trim();
+    if first.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(first))
 }
 
 /// Get binary modification time as unix timestamp

--- a/src/format.rs
+++ b/src/format.rs
@@ -363,16 +363,16 @@ pub fn strip_emojis(s: &str) -> String {
 
 /// Format directory path with home replacement and color
 pub fn format_directory(path: &str) -> String {
-    use std::env;
+    let home = crate::paths::home_dir()
+        .ok()
+        .and_then(|p| {
+            p.to_str()
+                .map(String::from)
+        });
 
-    let formatted = if let Ok(home) = env::var("HOME") {
-        if path.starts_with(&home) {
-            path.replacen(&home, "~", 1)
-        } else {
-            path.to_string()
-        }
-    } else {
-        path.to_string()
+    let formatted = match home {
+        Some(h) if path.starts_with(&h) => path.replacen(&h, "~", 1),
+        _ => path.to_string(),
     };
 
     formatted

--- a/src/install.rs
+++ b/src/install.rs
@@ -57,9 +57,17 @@ pub fn install() -> Result<()> {
     // Get the current binary path
     let binary_path =
         std::env::current_exe().context("Failed to determine current executable path")?;
-    let binary_path_str = binary_path
+    let raw = binary_path
         .to_str()
         .context("Binary path contains invalid UTF-8")?;
+    // Claude Code invokes statusLine commands via Git Bash on Windows, so backslashes
+    // in the path would be interpreted as escape characters. Use forward slashes instead.
+    let binary_path_str: std::borrow::Cow<str> = if cfg!(windows) {
+        raw.replace('\\', "/")
+            .into()
+    } else {
+        raw.into()
+    };
 
     // Create statusLine configuration
     let status_line_config = json!({

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,5 +1,6 @@
 use crate::paths::claude_config_dir;
 use anyhow::{Context, Result};
+use path_slash::PathExt;
 use serde_json::{Value, json};
 use std::fs;
 use std::io::{self, Write};
@@ -54,20 +55,22 @@ pub fn install() -> Result<()> {
         }
     }
 
-    // Get the current binary path
+    // Get the current binary path. Claude Code invokes statusLine via Git Bash on
+    // Windows: backslashes are escape chars and \\?\/UNC prefixes are unrunnable.
+    // dunce::simplified strips verbatim prefixes when safe; path-slash converts
+    // separators. Both are no-ops on Unix.
     let binary_path =
         std::env::current_exe().context("Failed to determine current executable path")?;
-    let raw = binary_path
-        .to_str()
+    let binary_path_str = dunce::simplified(&binary_path)
+        .to_slash()
         .context("Binary path contains invalid UTF-8")?;
-    // Claude Code invokes statusLine commands via Git Bash on Windows, so backslashes
-    // in the path would be interpreted as escape characters. Use forward slashes instead.
-    let binary_path_str: std::borrow::Cow<str> = if cfg!(windows) {
-        raw.replace('\\', "/")
-            .into()
-    } else {
-        raw.into()
-    };
+    if cfg!(windows) && binary_path_str.starts_with("\\\\") {
+        anyhow::bail!(
+            "Binary path uses an extended-length or UNC prefix Git Bash cannot execute: {}\n\
+             Install under a regular drive path (e.g. C:/Users/<you>/.local/bin/).",
+            binary_path_str
+        );
+    }
 
     // Create statusLine configuration
     let status_line_config = json!({

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -3,9 +3,10 @@ use std::fs;
 use std::path::PathBuf;
 
 pub fn home_dir() -> Result<PathBuf> {
-    std::env::var("HOME")
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
-        .context("HOME not set")
+        .context("HOME (or USERPROFILE on Windows) not set")
 }
 
 pub fn claude_config_dir() -> Result<PathBuf> {


### PR DESCRIPTION
Five focused changes to make ccusage-statusline-rs build and run correctly
  on Windows.

  **Changes**

  - chore(deps): remove libc, use std::env::temp_dir for cache directory
    libc::getuid() is Unix-only and required an unsafe block. std::env::temp_dir()
    covers all platforms and falls back gracefully when XDG_RUNTIME_DIR is absent.

  - fix: fall back to USERPROFILE for home directory on Windows
    Windows does not set HOME. home_dir() now checks USERPROFILE as a fallback.
    format_directory() is updated to reuse home_dir() rather than reading HOME
    directly.

  - fix: use `where` instead of `which` to locate Claude binary on Windows
    `which` is not available on Windows; `where` is the equivalent. Also handles
    the case where `where` returns multiple matches by taking the first line only.

  - fix: normalize path separators written by install command on Windows
    Claude Code invokes statusLine commands through Git Bash on Windows. Backslashes
    in the command path are treated as escape characters by bash, causing silent
    failure with no error surfaced to the user. The install command now writes
    forward slashes on Windows.

  - docs: add Windows installation and configuration notes
    PowerShell install steps, forward-slash requirement for manual configuration,
    and TEMP fallback for the cache directory.

  **Tested on**

  Windows 11, Claude Code 2.1.119, Git Bash 2.47.